### PR TITLE
chore: Remove deprecated module name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,13 +89,6 @@ pub mod prelude {
     pub use super::Waitable as _;
 }
 
-#[doc(hidden)]
-#[deprecated(since = "0.1.1", note = "use `wait::prelude::*` instead")]
-pub mod preamble {
-    #[doc(hidden)]
-    pub use super::Waitable as _;
-}
-
 #[cfg(test)]
 mod tests {
     use super::prelude::*;


### PR DESCRIPTION
This pull request removes a deprecated module name. It also serves as a test of `release-plz` because this is technically a breaking change (even though the first release was published late last night and is unlikely to be in use).