### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/FlippingBinaryLLC/wait-rs/compare/v0.1.1...v0.2.0) - 2024-11-01
+
+### Added
+
+- Add the new `std` default feature flag
+
+### Fixed
+
+- Linting error
+
+### Other
+
+- Update `README.md` to describe building with `no_std`
+- Relax the linter's restriction on unsafe code
+- Remove deprecated module name

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "wait"
 repository = "https://github.com/FlippingBinaryLLC/wait-rs"
 rust-version = "1.56.1"
-version = "0.1.1"
+version = "0.2.0"
 
 exclude = [".gitignore", ".github", ".markdownlint.jsonc"]
 


### PR DESCRIPTION
## 🤖 New release
* `wait`: 0.1.1 -> 0.2.0 (⚠️ API breaking changes)

### ⚠️ `wait` breaking changes

```
--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/module_missing.ron

Failed in:
  mod wait::preamble, previously in file /tmp/.tmp50bH7L/wait/src/lib.rs:94
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/FlippingBinaryLLC/wait-rs/compare/v0.1.1...v0.2.0) - 2024-11-01

### Added

- Add the new `std` default feature flag

### Fixed

- Linting error

### Other

- Update `README.md` to describe building with `no_std`
- Relax the linter's restriction on unsafe code
- Remove deprecated module name
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).