### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/FlippingBinaryLLC/wait-rs/compare/v0.2.0...v0.2.1) - 2024-11-01
+
+### Other
+
+- Update version number
+
 ## [0.2.0](https://github.com/FlippingBinaryLLC/wait-rs/compare/v0.1.1...v0.2.0) - 2024-11-01
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "wait"
 repository = "https://github.com/FlippingBinaryLLC/wait-rs"
 rust-version = "1.56.1"
-version = "0.2.0"
+version = "0.2.1"
 
 exclude = [".gitignore", ".github", ".markdownlint.jsonc"]
 


### PR DESCRIPTION
## 🤖 New release
* `wait`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/FlippingBinaryLLC/wait-rs/compare/v0.2.0...v0.2.1) - 2024-11-01

### Other

- Update version number
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).