### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/FlippingBinaryLLC/wait-rs/compare/v0.2.2...v0.2.3) - 2024-11-08
+
+### Fixed
+
+- Doc-test should ignore the incomplete example in the `README.md`
+- Ensure `tokio` feature is enabled when building example that requires it
+
+### Other
+
+- Simplify the main docs
+- Add link to GitHub repository in `README.md`
+- Improve clarity of prelude documentation
+- Add favicon
+- Add clarification in example
+
 ## [0.2.2](https://github.com/FlippingBinaryLLC/wait-rs/compare/v0.2.1...v0.2.2) - 2024-11-03
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "wait"
 repository = "https://github.com/FlippingBinaryLLC/wait-rs"
 rust-version = "1.56.1"
-version = "0.2.2"
+version = "0.2.3"
 
 exclude = [".gitignore", ".github", ".markdownlint.jsonc"]
 


### PR DESCRIPTION
## 🤖 New release
* `wait`: 0.2.2 -> 0.2.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.3](https://github.com/FlippingBinaryLLC/wait-rs/compare/v0.2.2...v0.2.3) - 2024-11-08

### Fixed

- Doc-test should ignore the incomplete example in the `README.md`
- Ensure `tokio` feature is enabled when building example that requires it

### Other

- Simplify the main docs
- Add link to GitHub repository in `README.md`
- Improve clarity of prelude documentation
- Add favicon
- Add clarification in example
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).