### PR TITLE
chore: release v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/FlippingBinaryLLC/wait-rs/compare/v0.2.4...v0.2.5) - 2024-11-09
+
+### Fixed
+
+- It should not panic if run from a `tokio` runtime without I/O or timer drivers
+
+### Other
+
+- Relax tokio dependency version to improve flexibility
+- Switch to tokio/rt instead of tokio/r-multi-thread
+- Remove ambiguity around "by default" phrase
+
 ## [0.2.4](https://github.com/FlippingBinaryLLC/wait-rs/compare/v0.2.3...v0.2.4) - 2024-11-08
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "wait"
 repository = "https://github.com/FlippingBinaryLLC/wait-rs"
 rust-version = "1.56.1"
-version = "0.2.4"
+version = "0.2.5"
 
 exclude = [".gitignore", ".github", ".markdownlint.jsonc"]
 


### PR DESCRIPTION
## 🤖 New release
* `wait`: 0.2.4 -> 0.2.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.5](https://github.com/FlippingBinaryLLC/wait-rs/compare/v0.2.4...v0.2.5) - 2024-11-09

### Fixed

- It should not panic if run from a `tokio` runtime without I/O or timer drivers

### Other

- Relax tokio dependency version to improve flexibility
- Switch to tokio/rt instead of tokio/r-multi-thread
- Remove ambiguity around "by default" phrase
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).