### PR TITLE
chore: release v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/FlippingBinaryLLC/wait-rs/compare/v0.2.5...v0.2.6) - 2025-01-21
+
+### Fixed
+
+- cannot find function `block_in_place` in module `tokio::task`
+
 ## [0.2.5](https://github.com/FlippingBinaryLLC/wait-rs/compare/v0.2.4...v0.2.5) - 2024-11-09
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "wait"
 repository = "https://github.com/FlippingBinaryLLC/wait-rs"
 rust-version = "1.56.1"
-version = "0.2.5"
+version = "0.2.6"
 
 exclude = [".gitignore", ".github", ".markdownlint.jsonc"]
 


### PR DESCRIPTION
## 🤖 New release
* `wait`: 0.2.5 -> 0.2.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.6](https://github.com/FlippingBinaryLLC/wait-rs/compare/v0.2.5...v0.2.6) - 2025-01-21

### Fixed

- cannot find function `block_in_place` in module `tokio::task`
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).